### PR TITLE
Avoid redownloding .deb file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
 
 # Download deb
 - name: Download Elasticsearch deb
-  get_url: url={{ elasticsearch_download_url }}/elasticsearch-{{ elasticsearch_version }}.deb dest=/tmp mode=0440
+  get_url: url={{ elasticsearch_download_url }}/elasticsearch-{{ elasticsearch_version }}.deb dest=/tmp/elasticsearch-{{ elasticsearch_version }}.deb mode=0440
 
 # Uninstall previous version if applicable
 - name: Uninstalling previous version if applicable


### PR DESCRIPTION
The task `Download Elasticsearch deb` is now always downloading the `.deb` file.

For [get_url](https://github.com/ansible/ansible/blob/devel/library/network/get_url#L277-L279) to skip downloading the remote file, these conditions should be met:
- `dest` is not a directory
- `force` is `no`

``` pyhon
    if not dest_is_dir and os.path.exists(dest):
        if not force:
            module.exit_json(msg="file already exists", dest=dest, url=url, changed=False)
```

So specifying full path to the `dest` attr should fix this.
