### PR TITLE
add task to enable elasticsearch service start on boot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ elasticsearch_log_dir: /var/log/elasticsearch
 elasticsearch_data_dir: /var/lib/elasticsearch
 elasticsearch_work_dir: /tmp/elasticsearch
 elasticsearch_conf_dir: /etc/elasticsearch
+elasticsearch_service_startonboot: no
 
 # Non-Elasticsearch Defaults
 apt_cache_valid_time: 300 # seconds between "apt-get update" calls.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,3 +108,7 @@
 # Restart Elasticsearch
 - name: Restarting Elasticsearch
   service: name=elasticsearch state=restarted
+
+# Register Elasticsearch service to start on boot
+- name: Ensure Elasticsearch is started on boot
+  service: name=elasticsearch enabled={{ elasticsearch_service_startonboot }}


### PR DESCRIPTION
I expected the service to start automatically after a reboot. This change adds the ability to enable this feature but uses the default value of no to conform to the previous behaviour.
