### PR TITLE
Added node.local setting to elasticsearch config template

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -98,6 +98,12 @@ node.rack: {{ elasticsearch_node_rack }}
 node.max_local_storage_nodes: {{ elasticsearch_node_max_local_storage_nodes }}
 {% endif %}
 
+# Disable network discovery by setting the following (useful for development):
+# node.local: true
+{% if elasticsearch_node_local is defined %}
+node.local: {{ elasticsearch_node_local }}
+{% endif %}
+
 #################################### Index ####################################
 
 # You can set a number of options (such as shard/replica options, mapping


### PR DESCRIPTION
We found that setting "discovery.zen.ping.multicast.enabled: false" was not enough to prevent elasticsearch from discovering other nodes in the same LAN. Setting "node.local: true" resolved the problem.

See here:
http://elasticsearch-users.115913.n3.nabble.com/How-to-isolate-elastic-search-node-from-other-nodes-td3977389.html