### PR TITLE
Move all configuration into template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ elasticsearch_data_dir: /var/lib/elasticsearch
 elasticsearch_work_dir: /tmp/elasticsearch
 elasticsearch_conf_dir: /etc/elasticsearch
 elasticsearch_service_startonboot: no
+elasticsearch_service_state: started
 
 # Non-Elasticsearch Defaults
 apt_cache_valid_time: 300 # seconds between "apt-get update" calls.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 # Elasticsearch Ansible Handlers
 
 # Restart Elasticsearch
-- name: Restarting Elasticsearch
+- name: Restart Elasticsearch
   service: name=elasticsearch state=restarted

--- a/tasks/aws.yml
+++ b/tasks/aws.yml
@@ -22,35 +22,3 @@
     path="{{ elasticsearch_plugin_dir }}" state=directory
     owner={{ elasticsearch_user }} group={{ elasticsearch_group }}
     recurse=yes
-# Configure AWS Plugin
-- name: Configuring AWS Plugin
-  lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(discovery.type: ec2)$'
-    insertafter='^(#*\sDiscovery\s#*)$'
-    line="discovery.type: ec2"
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(discovery.ec2.groups.*)$'
-    insertafter='^(discovery.type: ec2)$'
-    line="discovery.ec2.groups: '{{ elasticsearch_plugin_aws_ec2_groups }}'"
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(discovery.ec2.ping_timeout.*)$'
-    insertafter='^(discovery.ec2.groups.*)$'
-    line="discovery.ec2.ping_timeout: {{ elasticsearch_plugin_aws_ec2_ping_timeout }}"
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(cloud.node.auto_attributes.*)$'
-    insertafter='^(discovery.ec2.ping_timeout.*)$'
-    line="cloud.node.auto_attributes: true"
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(cloud.aws.access_key.*)$'
-    insertafter='^(cloud.node.auto_attributes.*)$'
-    line="cloud.aws.access_key: '{{ elasticsearch_plugin_aws_access_key }}'"
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(cloud.aws.secret_key.*)$'
-    insertafter='^(cloud.aws.access_key.*)$'
-    line="cloud.aws.secret_key: '{{ elasticsearch_plugin_aws_secret_key }}'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,19 +75,20 @@
   shell: "echo Configuring open file limits"
 - lineinfile: dest=/etc/security/limits.conf regexp='^{{ elasticsearch_user }}     -    nofile    {{ elasticsearch_max_open_files }}' insertafter=EOF line='{{ elasticsearch_user }}     -    nofile    {{ elasticsearch_max_open_files }}'
   when: elasticsearch_max_open_files is defined
+  notify: Restart Elasticsearch
 - lineinfile: dest=/etc/security/limits.conf regexp='^{{ elasticsearch_user }}     -    memlock   {{ elasticsearch_max_locked_memory }}' insertafter=EOF line='{{ elasticsearch_user }}     -    memlock   {{ elasticsearch_max_locked_memory }}'
   when: elasticsearch_max_locked_memory is defined
+  notify: Restart Elasticsearch
 - lineinfile: dest=/etc/pam.d/su regexp='^session    required   pam_limits.so' insertafter=EOF line='session    required   pam_limits.so'
+  notify: Restart Elasticsearch
 - lineinfile: dest=/etc/pam.d/common-session regexp='^session    required   pam_limits.so' insertafter=EOF line='session    required   pam_limits.so'
+  notify: Restart Elasticsearch
 - lineinfile: dest=/etc/pam.d/common-session-noninteractive regexp='^session    required   pam_limits.so' insertafter=EOF line='session    required   pam_limits.so'
+  notify: Restart Elasticsearch
 - lineinfile: dest=/etc/pam.d/sudo regexp='^session    required   pam_limits.so' insertafter=EOF line='session    required   pam_limits.so'
+  notify: Restart Elasticsearch
 - lineinfile: dest=/etc/init.d/elasticsearch regexp='^(DAEMON_OPTS=".*-Des.max-open-files=true")$' insertafter='^(DAEMON_OPTS=".*CONF_DIR")$' line='DAEMON_OPTS="$DAEMON_OPTS -Des.max-open-files=true"'
-
-# Configure Elasticsearch Node
-- name: Configuring Elasticsearch Node
-  template: src=elasticsearch.yml.j2 dest={{ elasticsearch_conf_dir }}/elasticsearch.yml owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
-  when: elasticsearch_conf_dir is defined
-- template: src=elasticsearch.default.j2 dest=/etc/default/elasticsearch owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
+  notify: Restart Elasticsearch
 
 # Install AWS Plugin
 - include: aws.yml
@@ -105,10 +106,15 @@
 - include: marvel.yml
   when: (elasticsearch_plugin_marvel_version is defined)
 
-# Restart Elasticsearch
-- name: Restarting Elasticsearch
-  service: name=elasticsearch state=restarted
+# Configure Elasticsearch Node
+- name: Configuring Elasticsearch Node
+  template: src=elasticsearch.yml.j2 dest={{ elasticsearch_conf_dir }}/elasticsearch.yml owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
+  when: elasticsearch_conf_dir is defined
+  notify: Restart Elasticsearch
+
+- template: src=elasticsearch.default.j2 dest=/etc/default/elasticsearch owner={{ elasticsearch_user }} group={{ elasticsearch_group }} mode=0644
+  notify: Restart Elasticsearch
 
 # Register Elasticsearch service to start on boot
 - name: Ensure Elasticsearch is started on boot
-  service: name=elasticsearch enabled={{ elasticsearch_service_startonboot }}
+  service: name=elasticsearch enabled={{ elasticsearch_service_startonboot }} state={{ elasticsearch_service_state }}

--- a/tasks/marvel.yml
+++ b/tasks/marvel.yml
@@ -22,35 +22,3 @@
     path="{{ elasticsearch_plugin_dir }}" state=directory
     owner={{ elasticsearch_user }} group={{ elasticsearch_group }}
     recurse=yes
-# Configure Marvel Plugin
-- name: Configuring Marvel Plugin
-  lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(marvel.agent.exporter.es.index.timeformat.*)$'
-    insertafter='^(#*\sVaria\s#*)$'
-    line="marvel.agent.exporter.es.index.timeformat: {{ elasticsearch_plugin_marvel_agent_exporter_es_index_timeformat }}"
-  when: elasticsearch_plugin_marvel_agent_exporter_es_index_timeformat is defined
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(marvel.agent.interval.*)$'
-    insertafter='^(#*\sVaria\s#*)$'
-    line="marvel.agent.interval: {{ elasticsearch_plugin_marvel_agent_interval }}"
-  when: elasticsearch_plugin_marvel_agent_interval is defined
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(marvel.agent.indices.*)$'
-    insertafter='^(#*\sVaria\s#*)$'
-    line="marvel.agent.indices: {{ elasticsearch_plugin_marvel_agent_indices }}"
-  when: elasticsearch_plugin_marvel_agent_indices is defined
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(marvel.agent.exporter.es.hosts.*)$'
-    insertafter='^(#*\sVaria\s#*)$'
-    line="marvel.agent.exporter.es.hosts: {{ elasticsearch_plugin_marvel_agent_exporter_es_hosts }}"
-  when: elasticsearch_plugin_marvel_agent_exporter_es_hosts is defined
-- lineinfile: >
-    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
-    regexp='^(marvel.agent.enabled.*)$'
-    insertafter='^(#*\sVaria\s#*)$'
-    line="marvel.agent.enabled: {{ elasticsearch_plugin_marvel_agent_enabled }}"
-  when: elasticsearch_plugin_marvel_agent_enabled is defined

--- a/tasks/spm.yml
+++ b/tasks/spm.yml
@@ -16,6 +16,7 @@
 # Configure JXM in Elasticsearch
 - name: Configuring JXM in Elasticsearch
   lineinfile: dest=/etc/default/elasticsearch regexp='^(ES_JAVA_OPTS="\$ES_JAVA_OPTS -Dcom.sun.management.jmxremote.*")$' insertafter='^(#ES_JAVA_OPTS=.*)$' line='ES_JAVA_OPTS="\$ES_JAVA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=3000 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"'
+  notify: Restart Elasticsearch
 
 # Configure JXM in SPM
 - name: Configuring JXM in SPM
@@ -24,7 +25,3 @@
 # Restart SPM
 - name: Restarting SPM
   service: name=spm-monitor state=restarted
-
-# Restart Elasticsearch
-- name: Restarting Elasticsearch
-  service: name=elasticsearch state=restarted

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -379,6 +379,21 @@ indices.recovery.concurrent_streams: {{ elasticsearch_recovery_concurrent_stream
 
 ################################## Discovery ##################################
 
+{% if elasticsearch_plugin_aws_version is defined %}
+
+discovery.type: ec2
+{% if elasticsearch_plugin_aws_ec2_groups is defined %}
+discovery.ec2.groups: '{{ elasticsearch_plugin_aws_ec2_groups }}'
+{% endif %}
+{% if elasticsearch_plugin_aws_ec2_ping_timeout is defined %}
+discovery.ec2.ping_timeout: {{ elasticsearch_plugin_aws_ec2_ping_timeout}}
+{% endif %}
+cloud.node.auto_attributes: true
+cloud.aws.access_key: '{{ elasticsearch_plugin_aws_access_key }}'
+cloud.aws.secret_key: '{{ elasticsearch_plugin_aws_secret_key }}'
+
+{% endif %}
+
 # Discovery infrastructure ensures nodes can be found within a cluster
 # and master node is elected. Multicast discovery is the default.
 
@@ -530,6 +545,26 @@ monitor.jvm.gc.ConcurrentMarkSweep.debug: {{ elasticsearch_gc_soncurrent_mark_sw
 {% endif %}
 
 ################################### Varia #####################################
+
+{% if elasticsearch_plugin_marvel_version is defined %}
+
+{% if elasticsearch_plugin_marvel_agent_exporter_es_index_timeformat is defined %}
+marvel.agent.exporter.es.index.timeformat: {{ elasticsearch_plugin_marvel_agent_exporter_es_index_timeformat }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_interval is defined %}
+marvel.agent.interval: {{ elasticsearch_plugin_marvel_agent_interval }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_indices is defined %}
+marvel.agent.indices: {{ elasticsearch_plugin_marvel_agent_indices }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_exporter_es_hosts is defined %}
+marvel.agent.exporter.es.hosts: {{ elasticsearch_plugin_marvel_agent_exporter_es_hosts }}
+{% endif %}
+{% if elasticsearch_plugin_marvel_agent_enabled is defined %}
+marvel.agent.enabled: {{ elasticsearch_plugin_marvel_agent_enabled }}
+{% endif %}
+
+{% endif %}
 
 {% if elasticsearch_misc_auto_create_index is defined %}
 action.auto_create_index: {{ elasticsearch_misc_auto_create_index }}


### PR DESCRIPTION
This allows a single action to trigger restarting elasticsearch if any
configuration changes. Also, it's simpler in terms of what variables
mean and how they influence the config.

This change effectively makes this role more idempotent so you can run
it multiple times and once the config has been written once, it'll not
change on the next run, meaning Elasticsearch only gets restarted when
something actually changes.