### PR TITLE
Allow enabling CORS handling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ elasticsearch_data_dir: /var/lib/elasticsearch
 elasticsearch_work_dir: /tmp/elasticsearch
 elasticsearch_conf_dir: /etc/elasticsearch
 elasticsearch_service_startonboot: no
+#elasticsearch_http_cors_enabled: "false"
 
 # Non-Elasticsearch Defaults
 apt_cache_valid_time: 300 # seconds between "apt-get update" calls.

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -548,3 +548,9 @@ action.disable_delete_all_indices: {{ elasticsearch_misc_disable_delete_all_indi
 {% if elasticsearch_script_disable_dynamic is defined %}
 script.disable_dynamic: {{ elasticsearch_script_disable_dynamic }}
 {% endif %}
+
+################################### CORS Settings #####################################
+
+{% if elasticsearch_http_cors_enabled is defined %}
+http.cors.enabled: {{ elasticsearch_http_cors_enabled }}
+{% endif %}


### PR DESCRIPTION
Since elasticsearch 1.4 the security settings no longer allow accessing the http interface from a javascript client deployed on a host/port different to the elasticsearch one. With setting cors enabled the http interface adds the required headers for OPTIONS requests to allow other host/port combinations to access the database. Having this cross origin resource sharing enabled is required to be able to use frontends like Kibana with elasticsearch 1.4.