### PR TITLE
Adding elasticsearch_plugin_aws_region option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The following variables provide a for now limited configuration for the plugin. 
 - elasticsearch_plugin_aws_ec2_ping_timeout
 - elasticsearch_plugin_aws_access_key
 - elasticsearch_plugin_aws_secret_key
+- elasticsearch_plugin_aws_region
 
 ### Installing plugins
 You will need to define an array called `elasticsearch_plugins` in your playbook or inventory, such that:

--- a/tasks/aws.yml
+++ b/tasks/aws.yml
@@ -11,6 +11,7 @@
 # - elasticsearch_plugin_aws_ec2_ping_timeout
 # - elasticsearch_plugin_aws_access_key
 # - elasticsearch_plugin_aws_secret_key
+# - elasticsearch_plugin_aws_region
 
 
 - name: Installing AWS Plugin
@@ -56,3 +57,9 @@
     insertafter='^(cloud.aws.access_key.*)$'
     line="cloud.aws.secret_key: '{{ elasticsearch_plugin_aws_secret_key }}'"
   when: elasticsearch_plugin_aws_secret_key is defined
+- lineinfile: >
+    dest="{{ elasticsearch_conf_dir }}/elasticsearch.yml"
+    regexp='^(cloud.aws.region.*)$'
+    insertafter='^(cloud.aws.secret_key.*)$'
+    line="cloud.aws.region: '{{ elasticsearch_plugin_aws_region }}'"
+  when: elasticsearch_plugin_aws_region is defined


### PR DESCRIPTION
Great ansible module, but contains a little glitch for european users : if no region is specified, the aws plugin will use eu-east-1, and ES instances in other regions won't be able to join into a cluster
Thanks for reviewing this