### PR TITLE
Add config option to disable EC2 discovery

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -387,7 +387,9 @@ indices.recovery.concurrent_streams: {{ elasticsearch_recovery_concurrent_stream
 
 {% if elasticsearch_plugin_aws_version is defined %}
 
+{% if elasticsearch_plugin_aws_discovery_disable is not defined %}
 discovery.type: ec2
+{% endif %}
 {% if elasticsearch_plugin_aws_ec2_groups is defined %}
 discovery.ec2.groups: '{{ elasticsearch_plugin_aws_ec2_groups }}'
 {% endif %}


### PR DESCRIPTION
This option is useful in the situation I encountered whereby I enabled the AWS plugin just for snapshots and did not want (or expect) auto-discovery.