### PR TITLE
Adding setting for scripting

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -608,6 +608,10 @@ script.disable_dynamic: {{ elasticsearch_script_disable_dynamic }}
 http.cors.enabled: {{ elasticsearch_http_cors_enabled }}
 {% endif %}
 
+{% if elasticsearch_script_groovy_sandbox_enabled is defined %}
+script.groovy.sandbox.enabled: {{ elasticsearch_script_groovy_sandbox_enabled }}
+{% endif %}
+
 
 ################################### Awareness Settings #####################################
 


### PR DESCRIPTION
As of 1.4.3, default is to disable groovy scripts, see http://www.elastic.co/guide/en/elasticsearch/reference/1.x/modules-scripting.html