### PR TITLE
Init script of some elasticsearch versions doesn't create /var/run/elasticsearch after reboot

### DIFF
--- a/templates/elasticsearch.default.j2
+++ b/templates/elasticsearch.default.j2
@@ -63,3 +63,5 @@ export ES_USE_GC_LOGGING=true
 {% if elasticsearch_java_home is defined %}
 JAVA_HOME={{ elasticsearch_java_home }}
 {% endif %}
+
+PID_DIR=/var/run


### PR DESCRIPTION
Init script of some elasticsearch versions doesn't create /var/run/elasticsearch after reboot which causes elasticsearch to crash. Specify /var/run as PID_DIR in the defaults file