### PR TITLE
Updated the inventory to no longer use password based login

### DIFF
--- a/vagrant-inventory.ini
+++ b/vagrant-inventory.ini
@@ -6,7 +6,7 @@
 # Local Environment #
 #####################
 [vagrant]
-192.168.111.10 ansible_ssh_user=vagrant ansible_ssh_pass=vagrant
+192.168.111.10 ansible_ssh_user=vagrant
 
 [vagrant:vars]
 # spm_client_token=<enter your token>


### PR DESCRIPTION
The current Vagrant configuration fails at startup. I think because how Vagrant changed it's prefered way to log into the VM. Removing the password from the inventory fixes the issue. 