### PR TITLE
fix variables that are not surrounded by {{}}

### DIFF
--- a/tasks/elastic-install.yml
+++ b/tasks/elastic-install.yml
@@ -11,7 +11,7 @@
   apt:
     pkg={{ item }}
     state=present
-  with_items: elasticsearch_apt_dependencies
+  with_items: "{{ elasticsearch_apt_dependencies }}"
 
 - name: elastic-install | Configuring elastic group
   group:

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -9,7 +9,7 @@
     repo={{ item }}
     state=present
     update_cache=yes
-  with_items: elasticsearch_apt_repos
+  with_items: "{{ elasticsearch_apt_repos }}"
 
 - name: java | Install dependencies
   apt:


### PR DESCRIPTION
These typos failed on ansible 2.2 for me.